### PR TITLE
Issue 4515 added plural name in model's definition

### DIFF
--- a/lib/specgen/model-helper.js
+++ b/lib/specgen/model-helper.js
@@ -74,6 +74,7 @@ var definitionFunction = function(modelCtor, typeRegistry, securityDefinitions, 
       lbdef.description || (lbdef.settings && lbdef.settings.description)),
     properties: {},
     required: [],
+    plural: modelCtor.pluralModelName
   };
 
   if (lbdef.settings && lbdef.settings.swagger && lbdef.settings.swagger.example) {


### PR DESCRIPTION
### Description
Model's plural name was not available in swagger.json, as this was required in BPMN-Api so added an extra node "plural" in definition